### PR TITLE
Updated location of cyrpto library based on changes merged into the CSDK  master

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ msg-broker-config=<THIS REPO>/aws_protocol_adaptor/device_client/cfg_aws.txt
    Current SDK version is 3, support for AWS IoT SDK version 4 is in our pipeline. (Version 4 is currently in Beta testing.)
 3. Download mbedTLS (before version 2.16) into `aws-iot-sdk/external_libs/mbedTLS` folder from https://github.com/ARMmbed/mbedtls
    Current AWS IoT SDK does not support 2.21 (development branch). They have an issue tracker for this: https://github.com/aws/aws-iot-device-sdk-embedded-C/issues/814
+   Run this command in the `aws-iot-sdk folder` to achieve this:
+   ```
+   wget -qO- https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.16.5.tar.gz | tar xvz -C external_libs/mbedTLS --strip-components=1
+   ```
 4. Run 'make' in `aws_protocol_adaptor/device_client`. (Or make clean to clean any compiled files.)
 
 Set message properties:

--- a/aws_protocol_adaptor/device_client/Makefile
+++ b/aws_protocol_adaptor/device_client/Makefile
@@ -55,7 +55,7 @@ IOT_SRC_FILES += $(shell find $(PLATFORM_COMMON_DIR)/ -name '*.c')
 #TLS - mbedtls
 MBEDTLS_DIR = $(IOT_CLIENT_DIR)/external_libs/mbedTLS
 TLS_LIB_DIR = $(MBEDTLS_DIR)/library
-CRYPTO_LIB_DIR = $(MBEDTLS_DIR)/crypto/library
+CRYPTO_LIB_DIR = $(MBEDTLS_DIR)/library
 TLS_INCLUDE_DIR = -I $(MBEDTLS_DIR)/include
 EXTERNAL_LIBS += -L$(TLS_LIB_DIR)
 LD_FLAG += -Wl,-rpath,$(TLS_LIB_DIR)


### PR DESCRIPTION
Changes at this location:

https://github.com/aws/aws-iot-device-sdk-embedded-C/commit/b0602a1ae85ea60750f81cce0ddeca089216cc93

*Issue #, if available:*

*Description of changes:*

The crypto library now goes into the library folder. Adjusted make file to fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
